### PR TITLE
feat: Fix handling of double back references. ...

### DIFF
--- a/json-spec-openapi.cabal
+++ b/json-spec-openapi.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                json-spec-openapi
-version:             1.0.0.0
+version:             1.0.1.0
 synopsis:            json-spec-openapi
 description:
   This package provides a way to produce

--- a/src/Data/JsonSpec/OpenApi.hs
+++ b/src/Data/JsonSpec/OpenApi.hs
@@ -342,13 +342,13 @@ instance Inlineable defs JsonRaw where
       & set type_ (Just OpenApiObject)
 instance {- Inlineable defs (JsonLet newDefs spec) -}
     ( Inlineable (Concat newDefs defs) spec
-    , Defs newDefs newDefs
+    , Defs (Concat newDefs defs) newDefs
     )
   =>
     Inlineable defs (JsonLet newDefs spec)
   where
     inlineable = do
-      mkDefs @newDefs @newDefs
+      mkDefs @(Concat newDefs defs) @newDefs
       inlineable @(Concat newDefs defs) @spec
 instance {- Inlineable defs (JsonRef target) -}
     ( Deref defs defs target


### PR DESCRIPTION
This fixes the schema generation for a certain type of double "back
reference", where the reference exits two or more enclosing JsonLet
scopes.