### PR TITLE
Add user-extensible schema modifier and poly-kinded annotation handling

### DIFF
--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -143,4 +143,4 @@ constraints: any.Cabal ==3.14.1.0,
              vector +boundschecks -internalchecks -unsafechecks -wall,
              any.vector-stream ==0.1.0.1,
              any.witherable ==0.5
-index-state: hackage.haskell.org 2026-02-01T04:15:37Z
+index-state: hackage.haskell.org 2026-02-05T10:14:40Z

--- a/json-spec-openapi.cabal
+++ b/json-spec-openapi.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                json-spec-openapi
-version:             1.1.0.0
+version:             1.2.0.0
 synopsis:            json-spec-openapi
 description:
   This package provides a way to produce


### PR DESCRIPTION
- Schema modifier hook: interpret "schema-modifier" annotation when
  value has kind Type; user defines SchemaModifier instance to modify
  generated schema (e.g. set description, readOnly). Use base type or
  any type with an instance; base type documented as most convenient.
- Poly-kind LookupAnnotation and ApplyAnnotations over [(Symbol, k)].
  Only [(Symbol, Type)] is interpreted for schema-modifier; overlappable
  catch-all instance makes all other annotation kinds no-op so other
  tools can use them without compile errors.
- Remove built-in description handling; description via SchemaModifier
  if desired. No re-export of Modifiable; target type as modifier is
  guideline, not requirement.
- Tests: AnnotatedUser with schema-modifier; empty annotations;
  symbol-valued "schema-modifier" ignored; Type-valued list without
  key no-op. Document that missing SchemaModifier instance gives type
  error.
- Module and SchemaModifier docs: annotations section, example, and
  modifier-type guidance.