### PR TITLE
Adapt to json-spec JsonEither list form (breaking change)

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc-version: ['9.8.1']
+        ghc-version: ['9.8.4']
         cabal-version: ['3.10.2.0']
     steps:
       # Checkout
@@ -89,10 +89,10 @@ jobs:
           packages: .
           constraints:
             aeson == 2.2.1.0,
-            base == 4.19.0.0,
+            base == 4.19.2.0,
             hspec == 2.11.1,
             insert-ordered-containers == 0.2.5.3,
-            json-spec == 1.2.0.0,
+            json-spec == 1.3.0.0,
             lens == 5.2.3,
             openapi3 == 3.2.4,
             text == 2.1,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+- Upgraded the json-spec dependency (adapts to json-spec 1.3 breaking change
+  where `JsonEither` takes a type-level list of specs instead of two
+  arguments).

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Rick Owens
+Copyright (c) 2026 Rick Owens
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -76,7 +76,7 @@ constraints: any.Cabal ==3.14.1.0,
              any.integer-logarithms ==1.0.5,
              integer-logarithms -check-bounds +integer-gmp,
              any.invariant ==0.6.5,
-             any.json-spec ==1.2.0.0,
+             any.json-spec ==1.3.0.0,
              any.kan-extensions ==5.2.8,
              any.lens ==5.3.6,
              lens -benchmark-uniplate -dump-splices +inlining -j +test-hunit +test-properties +test-templates +trustworthy,
@@ -143,4 +143,4 @@ constraints: any.Cabal ==3.14.1.0,
              vector +boundschecks -internalchecks -unsafechecks -wall,
              any.vector-stream ==0.1.0.1,
              any.witherable ==0.5
-index-state: hackage.haskell.org 2026-02-05T10:14:40Z
+index-state: hackage.haskell.org 2026-02-09T19:05:10Z

--- a/json-spec-openapi.cabal
+++ b/json-spec-openapi.cabal
@@ -52,7 +52,7 @@ license:             MIT
 license-file:        LICENSE
 author:              Rick Owens
 maintainer:          rick@owensmurray.com
-copyright:           2025 Owens Murray, LLC.
+copyright:           2026 Owens Murray, LLC.
 category:            JSON, OpenApi
 build-type:          Simple
 extra-source-files:

--- a/json-spec-openapi.cabal
+++ b/json-spec-openapi.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                json-spec-openapi
-version:             1.2.0.0
+version:             1.2.0.1
 synopsis:            json-spec-openapi
 description:
   This package provides a way to produce

--- a/json-spec-openapi.cabal
+++ b/json-spec-openapi.cabal
@@ -55,16 +55,17 @@ maintainer:          rick@owensmurray.com
 copyright:           2026 Owens Murray, LLC.
 category:            JSON, OpenApi
 build-type:          Simple
-extra-source-files:
+extra-doc-files:
   README.md
   LICENSE
+  CHANGELOG.md
 
 common dependencies
   build-depends:
     , aeson                     >= 2.2.1.0  && < 2.3
-    , base                      >= 4.19.0.0 && < 4.22
+    , base                      >= 4.19.2.0 && < 4.22
     , insert-ordered-containers >= 0.2.5.3  && < 0.3
-    , json-spec                 >= 1.2.0.0  && < 1.3
+    , json-spec                 >= 1.3.0.0  && < 1.4
     , lens                      >= 5.2.3    && < 5.4
     , openapi3                  >= 3.2.4    && < 3.3
     , text                      >= 2.1      && < 2.2

--- a/test/test.hs
+++ b/test/test.hs
@@ -64,18 +64,15 @@ main =
           actual =
             toOpenApiSchema (Proxy @(
               JsonEither
-                (
-                  JsonObject
+                '[ JsonObject
                     '[ Required "tag" (JsonTag "a")
                      , Required "content" JsonString
                      ]
-                )
-                (
-                  JsonObject
+                , JsonObject
                     '[ Required "tag" (JsonTag "b")
                      , Required "content" JsonString
                      ]
-                )
+                ]
             ))
 
           expected :: (Definitions OA.Schema, OA.Schema)


### PR DESCRIPTION
json-spec 1.3 changed JsonEither from two type arguments to a single
type-level list: JsonEither a b is now JsonEither '[a, b].

- Rename.hs: Match JsonEither specs, add Snd, GetEitherList, and
  RenameEitherList; remove RenameEither/RenameEither2/RenameEither3.
- OpenApi.hs: Add RefableList for [Specification]; Inlineable (JsonEither
  specs) now uses RefableList; add (<$>), (<*>) to Prelude import.
- test/test.hs: Use JsonEither '[ spec1, spec2 ] in sum test.

Build and tests pass.

Co-authored-by: Cursor <cursoragent@cursor.com>